### PR TITLE
Fix markdown, change link to CTAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 showexpl
 ========
 
-The LaTeX package 'showexpl' provides a way to typeset LaTeX source code and
-the related result in the same document. The `listings' package is required.
-See 'doc/showexpl-test.tex' for the details.
+The LaTeX package `showexpl` provides a way to typeset LaTeX source code and
+the related result in the same document. The `listings` package is required.
+See `doc/showexpl-test.tex` for the details.
 
 Recommended TDS locations:
-```
+
+```text
    showexpl.sty:                             tex/latex/showexpl
    README, showexpl.pdf, showexpl-test.pdf,
    showexpl-test.tex, result-picture.pdf:    doc/latex/showexpl
 ```
-For general installation advice, see
-http://www.tex.ac.uk/cgi-bin/texfaq2html?label=instpackages
 
-The showexpl document class is also on CTAN:[macros/latex/contrib/showexpl](http://www.ctan.org/tex-archive/macros/latex/contrib/showexpl)
+For general installation advice, see
+<http://www.tex.ac.uk/cgi-bin/texfaq2html?label=instpackages>
+
+The showexpl package is also on CTAN:[pkg/showexpl](https://www.ctan.org/pkg/showexpl)
 
 Rolf Niepraschk,
 email: Rolf.Niepraschk@gmx.de,


### PR DESCRIPTION
I am using [markdown-lint](https://github.com/DavidAnson/markdownlint) to enable "proper" markdown files. Applied the knowledge here.

Further, I hink https://www.ctan.org/pkg/showexpl is a more nice CTAN page than https://www.ctan.org/tex-archive/macros/latex/contrib/showexpl.

Finally, I think, this a package, not a document class, isn't it?