### PR TITLE
Build release ZIP using GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,13 @@ jobs:
           compiler: all
           args: all
           extra_system_packages: dist
-      - name: publish
+      - name: publish dist-archive
         uses: actions/upload-artifact@v2
         with:
           name: dist-archive
           path: showexpl*.zip
+      - name: publish showexpl.sty
+        uses: actions/upload-artifact@v2
+        with:
+          name: showexpl.sty
+          path: showexpl.sty

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+on: [push, pull_request]
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: make
+        uses: dante-ev/latex-action@master
+        with:
+          entrypoint: /usr/bin/make
+          # parameters are passed to make
+          # make doesn't want to cope with "" as parameter, thus we pass "all" at all places
+          # see https://github.com/dante-ev/latex-action/blob/master/action.yml for a list of all args passed by GitHub actions
+          root_file: all
+          working_directory: all
+          compiler: all
+          args: all
+          extra_system_packages: dist
+      - name: publish
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-archive
+          path: showexpl*.zip


### PR DESCRIPTION
Since the repository does not contain the `.sty` file, I needed to create it. This is an approach to build the whole project on each pull request and and on each push.

It will create a "build articat" on each succcessful build:

![grafik](https://user-images.githubusercontent.com/1366654/80970330-44ef0e00-8e1b-11ea-9a16-c82a8a4ce5db.png)

The contents of the uploaded archive will be `showexpl-yyyy-mm-dd.zip`:

![grafik](https://user-images.githubusercontent.com/1366654/80970372-533d2a00-8e1b-11ea-8a80-18d04eb0834b.png)
